### PR TITLE
Run the mongodb-grafana project using docker-compose

### DIFF
--- a/GrafanaDockerfile
+++ b/GrafanaDockerfile
@@ -1,0 +1,6 @@
+FROM grafana/grafana
+
+COPY . /var/lib/grafana/plugins/mongodb-grafana
+
+EXPOSE 3000
+

--- a/ProxyDockerfile
+++ b/ProxyDockerfile
@@ -1,0 +1,11 @@
+FROM node
+
+WORKDIR /usr/src/mongografanaproxy
+
+COPY . /usr/src/mongografanaproxy
+
+EXPOSE 3333
+
+RUN cd /usr/src/mongografanaproxy
+RUN npm install
+ENTRYPOINT ["npm","run","server"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,36 @@
+version: '3.5'
+
+services:
+  mongo:
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+    volumes:
+      - ${DB_PATH}:/data/db
+    networks:
+      - backend
+  mongo-proxy:
+    build:
+      context: .
+      dockerfile: ProxyDockerfile
+    restart: always
+    networks:
+      - backend
+  grafana:
+    build:
+      context: .
+      dockerfile: GrafanaDockerfile
+    restart: always
+    ports:
+      - 3000:3000
+    networks:
+      - backend
+      - frontend
+networks:
+  frontend:
+    name: frontend-network
+  backend:
+    name: backend-network
+    internal: true


### PR DESCRIPTION
This is a great project, which I was really in need of. Thank you 👍 
I added two dockerfiles to boostrap the experience.
One is for the proxy, thus a docker image is created for the proxy.
The other one is for the Grafana, thus we end up with a docker Grafana images which has preinstalled the 

Apparently the above can be used together using docker compose, thus with one line the user can have a mongodb instance, a mongodb proxy and the Grafana server with the mongodb plugin preinstalled.

```
docker-compose -f stack.yaml build
MONGO_USER=root MONGO_PASSWORD=root DB_PATH=~/grafana-mongo  docker-compose -f stack.yaml up
```

Kind Regards