### PR TITLE
Enable `minInterval` option

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -30,5 +30,9 @@
   "dependencies": {
     "grafanaVersion": "3.x.x",
     "plugins": [ ]
+  },
+
+  "queryOptions": {
+    "minInterval": true
   }
 }

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -30,5 +30,9 @@
   "dependencies": {
     "grafanaVersion": "3.x.x",
     "plugins": [ ]
+  },
+
+  "queryOptions": {
+    "minInterval": true
   }
 }


### PR DESCRIPTION
Thanks for mongodb plugin! :)

I found it useful to have this additional `minInterval` option in query editor, which I knew from other SQL datasources. 
This little change enables it. Probably it requires also newer grafana version(so dependency update in `plugin.json`), but I couldn't really find when exactly they added it to grafana. The closest place I found was this PR: https://github.com/grafana/grafana/issues/13157.

Best regards :)