### PR TITLE
modification to can use multivalue of variable with timeseries

### DIFF
--- a/dist/server/mongodb-proxy.js
+++ b/dist/server/mongodb-proxy.js
@@ -265,6 +265,15 @@ function parseQuery(query, substitutions)
                             obj[key] = substitutions[value]
                         }
                     }
+					if ( typeof(value) == "object" && Array.isArray(value) )
+					{
+						if ( value[0].includes('{') )
+						{
+							// remove accolade and create array
+							var val = value[0].replace('{','').replace('}','')
+							obj[key] = val.split(',')
+						}
+					}
                 })
           }
       }
@@ -411,8 +420,19 @@ function getTimeseriesResults(docs)
       dp = { 'target' : tg, 'datapoints' : [] }
       results[tg] = dp
     }
-    
-    results[tg].datapoints.push([doc['value'], doc['ts'].getTime()])
+	var valueName = 'value'
+	if ( !(valueName in doc) )
+	{
+		// search another name of column 
+		for (var propName in doc )
+		{
+			if ( propName != 'ts' )
+			{
+				valueName = propName
+			}
+		}
+	}
+    results[tg].datapoints.push([doc[valueName], doc['ts'].getTime()])
   }
   return results
 }

--- a/server/mongodb-proxy.js
+++ b/server/mongodb-proxy.js
@@ -265,6 +265,15 @@ function parseQuery(query, substitutions)
                             obj[key] = substitutions[value]
                         }
                     }
+					if ( typeof(value) == "object" && Array.isArray(value) )
+					{
+						if ( value[0].includes('{') )
+						{
+							// remove accolade and create array
+							var val = value[0].replace('{','').replace('}','')
+							obj[key] = val.split(',')
+						}
+					}
                 })
           }
       }
@@ -411,8 +420,19 @@ function getTimeseriesResults(docs)
       dp = { 'target' : tg, 'datapoints' : [] }
       results[tg] = dp
     }
-    
-    results[tg].datapoints.push([doc['value'], doc['ts'].getTime()])
+	var valueName = 'value'
+	if ( !(valueName in doc) )
+	{
+		// search another name of column 
+		for (var propName in doc )
+		{
+			if ( propName != 'ts' )
+			{
+				valueName = propName
+			}
+		}
+	}
+    results[tg].datapoints.push([doc[valueName], doc['ts'].getTime()])
   }
   return results
 }


### PR DESCRIPTION
column name 'ts' is always required, but name can be other than 'value'

ex:

db.IndoorAirQuality_V2.aggregate ( [
{ "$match" :    { "SenderBuildingEntity.Sentinel": { "$in" : ["$sentinelCO2"]},
  "Date": { "$gte" :  "$from" } }  },
{"$sort" : {"Date" : 1}},

{"$project" : {  "name" : "$SenderBuildingEntity.Sentinel",  "value" : "$Datas.CO2",  "ts" : "$Date",  "_id" : 0}  }
],
{"maxTimeMS":50000,"allowDiskUse":true})