### PR TITLE
Remove node restriction and allow $date objects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+from node:lts-alpine
+
+WORKDIR /app
+COPY dist/server /app
+COPY package.json /app
+
+RUN npm install --production
+
+VOLUME /app/config
+EXPOSE 3333
+
+CMD node mongodb-proxy.js

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
   "bugs": {
     "url": "https://github.com/JamesOsgood/mongodb-grafana/issues"
   },
-  "engines": {
-    "node": "6.10.0"
-  },
-  "engineStrict": true,
   "devDependencies": {
     "babel": "^6.23.0",
     "chai": "~3.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "devDependencies": {
     "babel": "^6.23.0",
+    "babel-plugin-transform-es2015-for-of": "^6.6.0",
+    "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "chai": "~3.5.0",
     "grunt": "^1.0.3",
     "grunt-babel": "~6.0.0",
@@ -33,19 +36,15 @@
     "grunt-systemjs-builder": "^1.0.0",
     "jsdom": "~9.12.0",
     "load-grunt-tasks": "^3.5.2",
+    "mocha": "^5.2.0",
     "prunk": "^1.3.0",
     "q": "^1.5.0"
   },
   "dependencies": {
-    "babel-plugin-transform-es2015-for-of": "^6.6.0",
-    "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
     "body-parser": "^1.18.3",
     "config": "^1.30.0",
     "express": "^4.16.3",
-    "fs": "0.0.1-security",
     "lodash": "^4.17.10",
-    "mocha": "^5.2.0",
     "moment": "^2.22.1",
     "mongodb": "^3.0.8",
     "statman-stopwatch": "^2.7.0"


### PR DESCRIPTION
I have:
- removed the node version restriction as it works with the latest LTS version of node
- change the `forIn` function to allow for deep value substitution, for example for $date objects
```javascript
db.events.aggregate([
    { "$match": { "event": "request", "time": { "$gte": { "$date": "$from" }, "$lt": { "$date": "$to" } }
])
```
- added a Dockerfile to generate a docker image that could be pushed to docker hub